### PR TITLE
Fix the gamemode list causing a bunch of error messages + improve Tools.ObjFindByScene

### DIFF
--- a/src/COAT/Tools.cs
+++ b/src/COAT/Tools.cs
@@ -64,6 +64,8 @@ public class Tools
         // "This fix... an ugly fix" - whyis2plus2
         // "Better than what I could of done in the weekend" - 𒀭𒅗𒅈𒈠
 
+        string childPath = null;
+
         string currentScene = Scene switch
         {
             "Main Menu" => "b3e7f2f8052488a45b35549efb98d902",
@@ -76,7 +78,16 @@ public class Tools
         var scene = SceneManager.GetSceneByName(currentScene);
         if (!scene.isLoaded) return null;
 
-        return (from obj in scene.GetRootGameObjects() where obj.name == FirstChild select obj).First();
+        if (FirstChild.Contains('/'))
+        {
+            string[] children = FirstChild.Split('/', 2);
+
+            FirstChild = children[0];
+            childPath = children[1];
+        }
+
+        var result = (from obj in scene.GetRootGameObjects() where obj.name == FirstChild select obj).First();
+        return string.IsNullOrEmpty(childPath)? result : result.transform.Find(childPath).gameObject;
     }
 
     #endregion

--- a/src/COAT/UI/Fragments/MainMenuAccess.cs
+++ b/src/COAT/UI/Fragments/MainMenuAccess.cs
@@ -32,7 +32,7 @@ public class MainMenuAccess : CanvasSingleton<MainMenuAccess>
     public void Rebuild()
     {
         // Sets the parent for the leftside UI and remove the text
-        leftside = Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Main Menu (1)/LeftSide").gameObject;
+        leftside = Tools.ObjFindByScene("Main Menu", "Canvas/Main Menu (1)/LeftSide");
                 
         // disable the V1 wake text
         leftside.transform.Find("Text (2)").gameObject.SetActive(false);

--- a/src/COAT/UI/Menus/GamemodeList.cs
+++ b/src/COAT/UI/Menus/GamemodeList.cs
@@ -70,6 +70,7 @@ namespace COAT.UI.Menus
 
                 // gamemode settings menu
                 UIB.Image(name, table, new(225, 0, 400, 450), null, fill: false);
+                Rebuild();
 
             });
 
@@ -140,16 +141,8 @@ namespace COAT.UI.Menus
 
         public void Toggle()
         {
-            creationLobby = new SudoLobby();
-
-            if (!Shown)
-            {
-                UI.HideCentralGroup();
-            }
-
+            if (!Shown) UI.HideCentralGroup();
             gameObject.SetActive(Shown = !Shown);
-            //Movement.UpdateState();
-            Rebuild();
         }
     }
 }

--- a/src/COAT/UI/Menus/GamemodeList.cs
+++ b/src/COAT/UI/Menus/GamemodeList.cs
@@ -153,10 +153,10 @@ public class ServerDiffifcultySelect : IMenuInterface
 
     public void Toggle()
     {
-        loadViaServer = !Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Difficulty Select (1)").gameObject.activeSelf;
-        Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Difficulty Select (1)").gameObject.SetActive(loadViaServer);
+        loadViaServer = !Tools.ObjFindByScene("Main Menu", "Canvas/Difficulty Select (1)").activeSelf;
+        Tools.ObjFindByScene("Main Menu", "Canvas/Difficulty Select (1)").SetActive(loadViaServer);
 
-        if (Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Main Menu (1)").gameObject.activeSelf)
-            Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Main Menu (1)").gameObject.SetActive(false);
+        if (Tools.ObjFindByScene("Main Menu", "Canvas/Main Menu (1)").activeSelf)
+            Tools.ObjFindByScene("Main Menu", "Canvas/Main Menu (1)").SetActive(false);
     }
 }

--- a/src/COAT/UI/UI.cs
+++ b/src/COAT/UI/UI.cs
@@ -89,7 +89,7 @@ public class UI
     public static void PushStack(IMenuInterface Current)
     {
         if (MenuStack.Count == 0)
-            Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Main Menu (1)").gameObject.SetActive(false);
+            Tools.ObjFindByScene("Main Menu", "Canvas/Main Menu (1)").SetActive(false);
         else
             MenuStack[MenuStack.Count - 1].Toggle();
 
@@ -107,7 +107,7 @@ public class UI
         MenuStack.RemoveAt(MenuStack.Count - 1);
 
         if (MenuStack.Count == 0)
-            Tools.ObjFindByScene("Main Menu", "Canvas").transform.Find("Main Menu (1)").gameObject.SetActive(true);
+            Tools.ObjFindByScene("Main Menu", "Canvas/Main Menu (1)").SetActive(true);
         else
             MenuStack[MenuStack.Count - 1].Toggle();
     }


### PR DESCRIPTION
- fixed a bunch of error messages that would show up after opening the lobby creator/gamemode list
- made it so that Tools.ObjFindByScene can take entire paths instead of just the name of a root object